### PR TITLE
Fix s390x filename case in Trivy script

### DIFF
--- a/gha-script/scanner-scripts/trivy_code_scan.sh
+++ b/gha-script/scanner-scripts/trivy_code_scan.sh
@@ -9,7 +9,7 @@ if [ "$validate_build_script" == true ]; then
 
     echo "[INFO] Fetching latest Trivy version..."
     TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
-    FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-S390X.tar.gz"
+    FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-s390x.tar.gz"
     CHECKSUM_FILE="trivy_${TRIVY_VERSION#v}_checksums.txt"
 
     echo "[INFO] Downloading Trivy binary..."

--- a/gha-script/scanner-scripts/trivy_image_scan.sh
+++ b/gha-script/scanner-scripts/trivy_image_scan.sh
@@ -8,7 +8,7 @@ if [ "$build_docker" == true ]; then
 
 	echo "Fetching latest Trivy version..."
 	TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
-	FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-S390X.tar.gz"
+	FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-s390x.tar.gz"
 	CHECKSUM_FILE="trivy_${TRIVY_VERSION#v}_checksums.txt"
 
 	echo "Downloading Trivy binary..."

--- a/script/scanner-scripts/trivy_code_scan.sh
+++ b/script/scanner-scripts/trivy_code_scan.sh
@@ -11,7 +11,7 @@ if [ "$validate_build_script" == true ]; then
 
     echo "[INFO] Fetching latest Trivy version..."
     TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
-    FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-S390X.tar.gz"
+    FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-s390x.tar.gz"
     CHECKSUM_FILE="trivy_${TRIVY_VERSION#v}_checksums.txt"
 
     echo "[INFO] Downloading Trivy binary..."

--- a/script/scanner-scripts/trivy_image_scan.sh
+++ b/script/scanner-scripts/trivy_image_scan.sh
@@ -9,7 +9,7 @@ if [ "$build_docker" == true ]; then
 
 	echo "Fetching latest Trivy version..."
 	TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
-	FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-S390X.tar.gz"
+	FILE_NAME="trivy_${TRIVY_VERSION#v}_Linux-s390x.tar.gz"
 	CHECKSUM_FILE="trivy_${TRIVY_VERSION#v}_checksums.txt"
 
 	echo "Downloading Trivy binary..."


### PR DESCRIPTION
This PR fixes the download failure in the Trivy script caused by incorrect case in the s390x binary filename (Linux-S390X → Linux-s390x)