### PR TITLE
fonttools - v4.57.0 - add wheel_build as true

### DIFF
--- a/f/fonttools/build_info.json
+++ b/f/fonttools/build_info.json
@@ -3,6 +3,7 @@
   "package_name": "fonttools",
   "github_url": "https://github.com/fonttools/fonttools",
   "version": "4.57.0",
+  "wheel_build" : true,
   "default_branch": "master",
   "package_dir": "f/fonttools/",
   "build_script": "fonttools_ubi_9.7.sh",


### PR DESCRIPTION
Update build_info.json to add wheel_build as true option