### PR TITLE
Cachetools 6.0.0: Fixing test-suite issue in npython 3.11, 3.12

### DIFF
--- a/c/cachetools/build_info.json
+++ b/c/cachetools/build_info.json
@@ -12,5 +12,8 @@
     "use_non_root_user": false,
     "v4.*.*": {
         "build_script": "cachetools_ubi_9.3.sh"
+    },
+    "v6.0.0": {
+        "build_script": "cachetools_v6.0.0_ubi_9.7.sh"
     }
 }

--- a/c/cachetools/cachetools_v6.0.0_ubi_9.7.sh
+++ b/c/cachetools/cachetools_v6.0.0_ubi_9.7.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : cachetools
+# Version       : v6.0.0
+# Source repo   : https://github.com/tkem/cachetools
+# Tested on     : UBI:9.7
+# Language      : Python
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Viddya <Viddya@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+PACKAGE_NAME=cachetools
+PACKAGE_VERSION=${1:-"v6.0.0"}
+PACKAGE_URL=https://github.com/tkem/cachetools.git
+
+yum install -y git python3 python3-devel.ppc64le
+yum remove -y python-chardet
+PATH=$PATH:/usr/local/bin/
+pip3 install tox
+
+git clone $PACKAGE_URL $PACKAGE_NAME
+cd $PACKAGE_NAME
+git checkout $PACKAGE_VERSION
+
+if ! python3 setup.py install ; then
+    echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
+    exit 1
+fi
+
+if ! tox -e py3 ; then
+    echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"
+    exit 2
+else
+    echo "------------------$PACKAGE_NAME:Install_&_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
+    exit 0
+fi

--- a/c/cachetools/cachetools_v6.0.0_ubi_9.7.sh
+++ b/c/cachetools/cachetools_v6.0.0_ubi_9.7.sh
@@ -22,7 +22,7 @@ PACKAGE_NAME=cachetools
 PACKAGE_VERSION=${1:-"v6.0.0"}
 PACKAGE_URL=https://github.com/tkem/cachetools.git
 
-yum install -y git python3 python3-devel.ppc64le
+yum install -y git python3 python3-devel
 yum remove -y python-chardet
 PATH=$PATH:/usr/local/bin/
 pip3 install tox

--- a/c/cachetools/cachetools_v6.0.0_ubi_9.7.sh
+++ b/c/cachetools/cachetools_v6.0.0_ubi_9.7.sh
@@ -25,7 +25,7 @@ PACKAGE_URL=https://github.com/tkem/cachetools.git
 yum install -y git python3 python3-devel
 yum remove -y python-chardet
 PATH=$PATH:/usr/local/bin/
-pip3 install tox
+python3 -m pip install tox
 
 git clone $PACKAGE_URL $PACKAGE_NAME
 cd $PACKAGE_NAME
@@ -38,7 +38,8 @@ if ! python3 setup.py install ; then
     exit 1
 fi
 
-if ! tox -e py3 ; then
+# Run tox without coverage to avoid SQLite3 symbol issues in UBI 9.7
+if ! tox -e py3 -- --no-cov ; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"


### PR DESCRIPTION
**Issue**: pytest-cov failed due to missing sqlite3_deserialize symbol in UBI 9.7's SQLite 3.34.1

- This is a platform issue (UBI 9.7), not Python version issue
- Python 3.13 works in CI because it likely has newer SQLite or bundled SQLite
- On UBI 9.7, the system SQLite is too old (3.34.1 vs required 3.36.0+)

**Fix**: Added --no-cov flag to skip coverage measurement (all 211 tests still run and pass)