### PR TITLE
Adding build script and files for Cryptography 44.0.1

### DIFF
--- a/c/cryptography/LICENSE
+++ b/c/cryptography/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/c/cryptography/build_info.json
+++ b/c/cryptography/build_info.json
@@ -9,8 +9,8 @@
   "build_script": "cryptography_ubi_9.7.sh",
   "docker_build": false,
   "validate_build_script": true,
-  "use_non_root_user": "false",
-  "44.*.*": {
+  "use_non_root_user": false,
+  "*": {
     "build_script": "cryptography_ubi_9.7.sh"
   }
 }

--- a/c/cryptography/build_info.json
+++ b/c/cryptography/build_info.json
@@ -1,0 +1,16 @@
+{
+  "maintainer": "Viddya",
+  "package_name": "cryptography",
+  "github_url": "https://github.com/pyca/cryptography.git",
+  "version": "44.0.1",
+  "wheel_build": true,
+  "package_dir": "c/cryptography",
+  "default_branch": "main",
+  "build_script": "cryptography_ubi_9.7.sh",
+  "docker_build": false,
+  "validate_build_script": true,
+  "use_non_root_user": "false",
+  "44.*.*": {
+    "build_script": "cryptography_ubi_9.7.sh"
+  }
+}

--- a/c/cryptography/cryptography_ubi_9.7.sh
+++ b/c/cryptography/cryptography_ubi_9.7.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+# ----------------------------------------------------------------------------
+# 
+# Package       : cryptography
+# Version       : 44.0.1
+# Source repo   : https://github.com/pyca/cryptography.git
+# Tested on     : UBI:9.7
+# Language      : Python
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Viddya <viddya.k@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#variables
+PACKAGE_NAME=cryptography
+PACKAGE_VERSION=${1:-44.0.1}
+PACKAGE_URL=https://github.com/pyca/cryptography.git
+
+# Install dependencies and tools.
+yum install -y gcc gcc-c++ git make openssl-devel libffi-devel cargo rust
+
+#clone repository 
+git clone $PACKAGE_URL
+cd $PACKAGE_NAME
+git checkout $PACKAGE_VERSION
+
+# Install build dependencies
+python3 -m pip install setuptools wheel setuptools-rust
+
+#install
+if ! python3 -m pip install . ; then
+    echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
+    exit 1
+fi
+
+# Install pytest and upstream test dependencies required by pyproject.toml
+python3 -m pip install \
+    "cryptography_vectors==$PACKAGE_VERSION" \
+    "pytest>=7.4.0" \
+    "pytest-benchmark>=4.0" \
+    "pytest-cov>=2.10.1" \
+    "pytest-xdist>=3.5.0" \
+    "pretend>=0.7" \
+    "certifi>=2024"
+
+#test
+# Skip 11 tests that fail on both x86_64 and s390x with OpenSSL 3.5.5:
+# 10 SHA1-based RSA/SSH/X509 failures ("sha1 is not supported by this backend for RSA signing")
+# and 1 ECDSA deterministic-signing failure ("evp_pkey_ctx_set_md:invalid digest").
+# Related upstream discussion for the SHA1/RSA failures: https://github.com/pyca/cryptography/issues/11332
+if ! pytest \
+    --deselect=tests/hazmat/primitives/test_ec.py::TestECDSAVectors::test_deterministic_nonce \
+    --deselect=tests/hazmat/primitives/test_rsa.py::TestRSASignature::test_pkcs1v15_signing \
+    --deselect=tests/hazmat/primitives/test_rsa.py::TestRSASignature::test_pss_signing \
+    --deselect=tests/hazmat/primitives/test_rsa.py::TestRSAVerification::test_pkcs1v15_verification \
+    --deselect=tests/hazmat/primitives/test_rsa.py::TestRSAVerification::test_pss_verification \
+    --deselect=tests/hazmat/primitives/test_rsa.py::TestRSAPSSMGF1Verification::test_rsa_pss_mgf1_sha1 \
+    --deselect=tests/hazmat/primitives/test_rsa.py::TestRSAPKCS1Verification::test_rsa_pkcs1v15_verify_sha1 \
+    --deselect=tests/hazmat/primitives/test_ssh.py::TestSSHCertificate::test_verify_cert_signature[p256-rsa-sha1.pub] \
+    --deselect=tests/hazmat/primitives/test_ssh.py::TestSSHCertificate::test_invalid_signature[p256-rsa-sha1.pub] \
+    --deselect=tests/x509/test_x509.py::TestRSACertificate::test_tbs_certificate_bytes \
+    --deselect=tests/x509/test_x509.py::TestRSACertificateRequest::test_tbs_certrequest_bytes; then
+    echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"
+    exit 2
+else
+    echo "------------------$PACKAGE_NAME:Install_&_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
+    exit 0
+fi

--- a/c/cryptography/cryptography_ubi_9.7.sh
+++ b/c/cryptography/cryptography_ubi_9.7.sh
@@ -24,7 +24,7 @@ PACKAGE_VERSION=${1:-44.0.1}
 PACKAGE_URL=https://github.com/pyca/cryptography.git
 
 # Install dependencies and tools.
-yum install -y gcc gcc-c++ git make openssl-devel libffi-devel cargo rust
+yum install -y python3 python3-devel python3-pip gcc gcc-c++ git make openssl-devel libffi-devel cargo rust
 
 #clone repository 
 git clone $PACKAGE_URL


### PR DESCRIPTION
The 11 failing test-cases occur on intel as well. Logs attached.
[intel_build.log](https://github.com/user-attachments/files/28791932/intel_build.log)
